### PR TITLE
Add Bosgame M5 SSD variation: Yangtze 2TB

### DIFF
--- a/Hardware/PCs/Bosgame_M5.md
+++ b/Hardware/PCs/Bosgame_M5.md
@@ -34,7 +34,7 @@ Disassembly video: https://www.youtube.com/watch?v=iJYixZ0G7YA
 
 **RAM**: A unit bought in October 2025 had Samsung K3KLALA0EM-MGCV RAM (9600Mhz). Another unit bought in December 2025 had Micron MT62F4G32D8DV-023 WT memory (8533Mhz). Note that the APU is limited to 8000Mhz at the moment so there shouldn't be any noticable difference.
 
-**SSD**: variations reported:
+**SSD** (reported variants):
 - KINGSTON OM8TAP42048K1-A00 M.2 2TB NVMe PCIe 4.0 x4 SSD with 640 TBW ([Datasheet](https://www.mouser.com/catalog/specsheets/Kingston_03-04-2025_OM8TAP4xxxxK1-A00_%20Product%20Specification_version_v1.0_10252024.pdf))
 - Yangtze PC41Q-2TB-B M.2 PCIe Gen4x4 NVMe (February 2026) ([Product Details](https://www.ymtc.com/en/products/35.html?cat=37))
 


### PR DESCRIPTION
My unit is shipped with a Yangtze 2TB SSD in February 2026. Adding it to the list of SSD variations.